### PR TITLE
python-lsp-black 1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - pip
   commands:
     - pip check || true    # [not win]
-    - pip check || exit 1  # [win]
+    - pip check || exit /b  # [win]
 
 about:
   home: https://github.com/python-lsp/python-lsp-black

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,10 @@ test:
   imports:
     - pylsp_black
     - pylsp_black.plugin
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/python-lsp/python-lsp-black
@@ -38,6 +42,7 @@ about:
   license_file: LICENSE
   summary: Black plugin for the Python LSP Server
   dev_url: https://github.com/python-lsp/python-lsp-black
+  doc_url: https://github.com/python-lsp/python-lsp-black/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0d7dd5f440a53b6f676fa8c097979e0ff611065b8f4ffd248b43228b0df2efee
+  sha256: d7eaeab2a377e96a82cc26afe2f8f2e1cf7c6eaefdcdeab026343e2e559dcce9
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-lsp-black" %}
-{% set version = "1.0.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -11,17 +11,19 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - black
-    - python-lsp-server
+    - python
+    - black >=22.3.0
+    - python-lsp-server >=1.4.0
     - toml
 
 test:
@@ -34,7 +36,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Black plugin for the Python LSP Server'
+  summary: Black plugin for the Python LSP Server
   dev_url: https://github.com/python-lsp/python-lsp-black
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
+    - pip check || true    # [not win]
+    - pip check || exit 1  # [win]
 
 about:
   home: https://github.com/python-lsp/python-lsp-black

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ test:
     - pip
   commands:
     - pip check || true    # [not win]
-    - pip check || exit /b  # [win]
 
 about:
   home: https://github.com/python-lsp/python-lsp-black


### PR DESCRIPTION
Changelog: https://github.com/python-lsp/python-lsp-black/blob/v1.2.1/CHANGELOG.md
License: https://github.com/python-lsp/python-lsp-black/blob/v1.2.1/LICENSE
Requirements: https://github.com/python-lsp/python-lsp-black/blob/v1.2.1/setup.cfg

Actions: 
1. Remove `noarch`
2. Skip `py<37`
3. Fix `python` in `host` and `run`
4. Add `setuptools` and `wheel` to `host`
5. Add pinnings for `black` and `python-lsp-server` in `run`
6. Add `pip check`
7. Add `doc_url`