### PR TITLE
python-lsp-black 2.0.0 (py313 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/rope-feedstock/pr13/5c40830
+  - https://staging.continuum.io/prefect/fs/python-lsp-server-feedstock/pr9/6211816

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8286d2d310c566844b3c116b824ada6fccfa6ba228b1a09a0526b74c04e0805f
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
 


### PR DESCRIPTION
python-lsp-black 2.0.0 

**Destination channel:** Defaults

### Links

- [PKG-7803]
- dev_url:        https://github.com/python-lsp/python-lsp-black
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- enable py313


[PKG-7803]: https://anaconda.atlassian.net/browse/PKG-7803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ